### PR TITLE
Wait for the cache to be ready upon start

### DIFF
--- a/src/cache.js
+++ b/src/cache.js
@@ -29,7 +29,15 @@ class TrufflePigCache extends EventEmitter {
       .on('add', async path => this.add(path))
       .on('change', async path => this.change(path))
       .on('error', error => this.emit('error', error))
-      .on('unlink', path => this.remove(path));
+      .on('unlink', path => this.remove(path))
+      .on('ready', () => {
+        const interval = setInterval(() => {
+          if (this._cache.size) {
+            clearInterval(interval);
+            this.emit('ready');
+          }
+        }, 1000);
+      });
     this._transform = transform || identity;
   }
   async _readFile(path: string): Promise<CacheObject> {

--- a/src/index.js
+++ b/src/index.js
@@ -57,7 +57,7 @@ class TrufflePig extends EventEmitter {
   apiUrl(endpoint: string): string {
     return `http://127.0.0.1:${this._options.port}${endpoint}`;
   }
-  createCache() {
+  async createCache() {
     const { contractDir, verbose } = this._options;
     this._cache = new ContractCache(contractDir);
 
@@ -75,6 +75,13 @@ class TrufflePig extends EventEmitter {
 
     this._cache.on('error', error => {
       this.emit('error', error);
+    });
+
+    return new Promise(resolve => {
+      this._cache.once('ready', () => {
+        if (verbose) this.emit('log', 'Cache ready');
+        resolve();
+      });
     });
   }
   createAccountCache() {
@@ -133,8 +140,8 @@ class TrufflePig extends EventEmitter {
       this.emit('ready', this.apiUrl(CONTRACTS_ENDPOINT));
     });
   }
-  start(): void {
-    this.createCache();
+  async start(): Promise<void> {
+    await this.createCache();
     this.createAccountCache();
     this.createServer();
   }


### PR DESCRIPTION
This PR simply makes the `start` function asynchronous, so that Trufflepig waits for the cache to be ready before starting. This is accomplished with a fairly naive approach by using the `ready` event from `chokidar.watch` and using an interval to check the cache size.

Resolves #22.