### PR TITLE
Add persistence cacheOption that is passed through to chokidar

### DIFF
--- a/src/cache.js
+++ b/src/cache.js
@@ -21,12 +21,15 @@ class TrufflePigCache extends EventEmitter {
 
   _transform: TransformFunction;
 
-  constructor(paths: Array<string> | string, { transform }: CacheOpts = {}) {
+  constructor(
+    paths: Array<string> | string,
+    { transform, persistent = true }: CacheOpts = {},
+  ) {
     super();
     this._cache = new Map();
     this._watcher = chokidar.watch(paths, {
       awaitWriteFinish: true,
-      persistent: true,
+      persistent,
     });
     this._watcher
       .on('add', async path => this.add(path))

--- a/src/flowtypes.js
+++ b/src/flowtypes.js
@@ -6,7 +6,8 @@ export type CacheObject = Object | null;
 export type TransformFunction = CacheObject => CacheObject;
 export type Cache = Map<string, Object>;
 export type CacheOpts = {
-  transform: TransformFunction,
+  transform?: TransformFunction,
+  persistent?: boolean,
 };
 
 // Because of https://github.com/facebook/flow/issues/5113
@@ -21,6 +22,7 @@ export type Server = {
 };
 
 export type TPOptions = {
+  cacheOptions?: CacheOpts,
   contractDir: string,
   ganacheKeyFile?: string,
   keystoreDir?: string,

--- a/src/index.js
+++ b/src/index.js
@@ -41,6 +41,7 @@ class TrufflePig extends EventEmitter {
   _server: $Application;
 
   constructor({
+    cacheOptions,
     contractDir,
     port = DEFAULT_PIG_PORT,
     verbose = false,
@@ -50,6 +51,7 @@ class TrufflePig extends EventEmitter {
   }: TPOptions) {
     super();
     this._options = {
+      cacheOptions,
       contractDir,
       port,
       verbose,
@@ -65,8 +67,8 @@ class TrufflePig extends EventEmitter {
   }
 
   async createCache() {
-    const { contractDir, verbose } = this._options;
-    this._cache = new ContractCache(contractDir);
+    const { contractDir, verbose, cacheOptions } = this._options;
+    this._cache = new ContractCache(contractDir, cacheOptions);
 
     this._cache.on('add', path => {
       if (verbose) this.emit('log', `Cache added: ${path}`);
@@ -93,7 +95,12 @@ class TrufflePig extends EventEmitter {
   }
 
   createAccountCache() {
-    const { ganacheKeyFile, keystoreDir, keystorePassword } = this._options;
+    const {
+      cacheOptions,
+      ganacheKeyFile,
+      keystoreDir,
+      keystorePassword,
+    } = this._options;
     if (ganacheKeyFile || keystoreDir) {
       this.emit(
         'log',
@@ -103,7 +110,7 @@ class TrufflePig extends EventEmitter {
     if (ganacheKeyFile) {
       const ganacheCache = KEY_PLUGINS.ganache(
         ganacheKeyFile,
-        {},
+        { cacheOptions },
         this.setAccounts.bind(this),
       );
       ganacheCache.on('error', this.emit.bind(this, 'error'));
@@ -111,7 +118,7 @@ class TrufflePig extends EventEmitter {
     if (keystoreDir) {
       const keystoreCache = KEY_PLUGINS.keystore(
         keystoreDir,
-        { password: keystorePassword },
+        { cacheOptions, password: keystorePassword },
         this.setAccounts.bind(this),
       );
       keystoreCache.on('error', this.emit.bind(this, 'error'));

--- a/src/key_plugins/ganache_key_plugin.js
+++ b/src/key_plugins/ganache_key_plugin.js
@@ -6,10 +6,10 @@ const Cache = require('../cache');
 
 const setup = (
   files: Array<string> | string,
-  opts: Object,
+  { cacheOptions }: Object,
   cb: Accounts => any,
 ) => {
-  const cache = new Cache(files);
+  const cache = new Cache(files, cacheOptions);
   // eslint-disable-next-line camelcase
   const parse = (_, { private_keys }) => {
     // We have to normalize the keys here and append 0x

--- a/src/key_plugins/keystore_key_plugin.js
+++ b/src/key_plugins/keystore_key_plugin.js
@@ -18,11 +18,12 @@ const getWalletData = async (
 
 const setup = (
   files: Array<string> | string,
-  opts: Object,
+  { password, cacheOptions }: Object,
   cb: Accounts => any,
 ) => {
   const cache = new Cache(files, {
-    transform: cacheObject => getWalletData(cacheObject, opts.password),
+    transform: cacheObject => getWalletData(cacheObject, password),
+    ...cacheOptions,
   });
   const parse = () => {
     cb(Object.assign({}, ...cache.values()));


### PR DESCRIPTION
This PR adds the ability to change the `persistence` option of the `chokidar` module. This is needed when we need to do a proper teardown in tests and need trufflepig to shut down all listeners. This will stop listening for changes after the first index so make sure you run trufflepig only after all contracts are already compiled when using this option.